### PR TITLE
BUGFIX: Don't strip numeric values from npm org - solves #571

### DIFF
--- a/packages/create-react-microservice/src/commands/default.js
+++ b/packages/create-react-microservice/src/commands/default.js
@@ -198,7 +198,6 @@ class CreateReactMicroService extends Command {
     if (str && str.length) {
       const namespace = str
         .replace(/\s/g, '-')
-        .replace(/[0-9]/g, '')
         .replace(/[^a-zA-Z-]/g, '')
         .toLowerCase();
 


### PR DESCRIPTION
<!--
Thanks a lot for your contribution, we really appreciate it! :heart:

If you haven't done so, please read through our `CONTRIBUTING.md` so we can accept your PR as fast as possible:
https://github.com/ImmoweltGroup/create-react-microservice/blob/master/CONTRIBUTING.md
-->

**What I did**

I fixed a bug in `create-react-microservice` which stripped numeric values when computing npm scope

**How I did it**

I removed the `.replace` which removed the numeric values

**How to verify it**

Run `create-react-microservice` and pass an org name with numeric values, such as `test39`. The computed org scope should be `@test39/`

**Checklist**

- [x] I executed `yarn run test` in the root of `create-react-microservice`
- [ ] I executed `yarn run test` in the `create-react-microservice-scaffold`
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the `master` branch.
